### PR TITLE
fix: correct hash position in decrypt function

### DIFF
--- a/samples/APIKeyAuthenticationSample/APIKeyAuthenticationSample.csproj
+++ b/samples/APIKeyAuthenticationSample/APIKeyAuthenticationSample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.0.0" />
+    <PackageReference Include="CipherKey" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/EventAuthenticationSample/EventAuthenticationSample.csproj
+++ b/samples/EventAuthenticationSample/EventAuthenticationSample.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.0.0" />
+    <PackageReference Include="CipherKey" Version="1.0.1" />
   </ItemGroup>
 </Project>

--- a/samples/MultiAuthenticationSample/MultiAuthenticationSample.csproj
+++ b/samples/MultiAuthenticationSample/MultiAuthenticationSample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.0.0" />
+    <PackageReference Include="CipherKey" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/ProviderAuthenticationSample/ProviderAuthenticationSample.csproj
+++ b/samples/ProviderAuthenticationSample/ProviderAuthenticationSample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.0.0" />
+    <PackageReference Include="CipherKey" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/CipherKey/CipherKey.csproj
+++ b/src/CipherKey/CipherKey.csproj
@@ -6,9 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>CipherKey</AssemblyName>
     <AssemblyTitle>CipherKey</AssemblyTitle>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
     <Product>CipherKey Library</Product>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Diandson C. Ramos</Authors>
     <Owners>Diandson C. Ramos</Owners>
     <Copyright>Copyright (c) 2023 Diandson C. Ramos</Copyright>

--- a/src/CipherKey/Utils/CipherKeyManager.cs
+++ b/src/CipherKey/Utils/CipherKeyManager.cs
@@ -145,8 +145,8 @@ namespace CipherKey.Utils
 
             using (Aes aesAlg = Aes.Create())
             {
-                aesAlg.Key = Encoding.UTF8.GetBytes(encryptionKey[^32..]);
-                aesAlg.IV = Encoding.UTF8.GetBytes(encryptionIV[^16..]);
+                aesAlg.Key = Encoding.UTF8.GetBytes(encryptionKey[..32]);
+                aesAlg.IV = Encoding.UTF8.GetBytes(encryptionIV[..16]);
                 aesAlg.Padding = PaddingMode.ISO10126;
 
                 using (var decryptor = aesAlg.CreateDecryptor(aesAlg.Key, aesAlg.IV))


### PR DESCRIPTION
Fixes the "Padding is invalid and cannot be removed" error in the decrypt function by ensuring the correct hash position is used for decryption.

Issue #23