### PR TITLE
feat: fix API key validation and update ProvideAsync method

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Diandson C. Ramos
+Copyright (c) 2024 Diandson C. Ramos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ public class MyCustomProvider : IApiKeyProvider
         new ApiKey("myApiKey35", "Adena") // Allow any origin
     };
 
-    public Task<IApiKey?> ProvideAsync(string key)
+    public Task<IApiKey?> ProvideAsync(string key, string? owner)
     {
         // Write your custom validation logic here.
         // Return an instance of a valid ApiKey or null for an invalid key.

--- a/samples/APIKeyAuthenticationSample/APIKeyAuthenticationSample.csproj
+++ b/samples/APIKeyAuthenticationSample/APIKeyAuthenticationSample.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.0.1" />
+    <PackageReference Include="CipherKey" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/EventAuthenticationSample/EventAuthenticationSample.csproj
+++ b/samples/EventAuthenticationSample/EventAuthenticationSample.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.0.1" />
+    <PackageReference Include="CipherKey" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/samples/MultiAuthenticationSample/Controllers/UserController.cs
+++ b/samples/MultiAuthenticationSample/Controllers/UserController.cs
@@ -82,5 +82,13 @@ namespace MultiAuthenticationSample.Controllers
         {
             return Ok("Get sucess as anonymous");
         }
+
+        // Action method requiring "msalPolicy" authorization policy and role "Manager".
+        [Authorize(Policy = "msalPolicy", Roles = "Manager")]
+        [HttpGet("msal-role")]
+        public IActionResult MsalPolicyWithRole()
+        {
+            return Ok($"Get success with user: {GetUserName()}");
+        }
     }
 }

--- a/samples/MultiAuthenticationSample/MultiAuthenticationSample.csproj
+++ b/samples/MultiAuthenticationSample/MultiAuthenticationSample.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="2.13.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.0.1" />
+    <PackageReference Include="CipherKey" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/MultiAuthenticationSample/Repositories/MyCustomProvider.cs
+++ b/samples/MultiAuthenticationSample/Repositories/MyCustomProvider.cs
@@ -13,7 +13,7 @@ namespace MultiAuthenticationSample.Repositories
             new ApiKey("cipher_key_provide_35", "Adena") // Allow any origin 
         };
 
-        public Task<IApiKey?> ProvideAsync(string key)
+        public Task<IApiKey?> ProvideAsync(string key, string? owner = null)
         {
             // Write your custom validation logic here.
             // Return an instance of a valid ApiKey or null for an invalid key.

--- a/samples/ProviderAuthenticationSample/ProviderAuthenticationSample.csproj
+++ b/samples/ProviderAuthenticationSample/ProviderAuthenticationSample.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.0.1" />
+    <PackageReference Include="CipherKey" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/ProviderAuthenticationSample/Repositories/MyCustomProvider.cs
+++ b/samples/ProviderAuthenticationSample/Repositories/MyCustomProvider.cs
@@ -13,7 +13,7 @@ namespace ProviderAuthenticationSample.Repositories
             new ApiKey("cipher_key_provide_35", "Adena") // Allow any origin 
         };
 
-        public Task<IApiKey?> ProvideAsync(string key)
+        public Task<IApiKey?> ProvideAsync(string key, string? owner)
         {
             // Write your custom validation logic here.
             // Return an instance of a valid ApiKey or null for an invalid key.

--- a/src/CipherKey/CipherKey.csproj
+++ b/src/CipherKey/CipherKey.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>CipherKey</AssemblyName>
     <AssemblyTitle>CipherKey</AssemblyTitle>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <AssemblyVersion>1.1.0</AssemblyVersion>
     <Product>CipherKey Library</Product>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Diandson C. Ramos</Authors>
     <Owners>Diandson C. Ramos</Owners>
-    <Copyright>Copyright (c) 2023 Diandson C. Ramos</Copyright>
+    <Copyright>Copyright (c) 2024 Diandson C. Ramos</Copyright>
     <Description>A library for API key authentication and encryption.</Description>
     <PackageId>CipherKey</PackageId>
     <PackageLicense>https://github.com/diandsonc/cipherKey/blob/master/LICENSE</PackageLicense>
@@ -24,6 +24,6 @@
     <RepositoryUrl>https://github.com/diandsonc/cipherKey</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="2.13.2" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/src/CipherKey/Events/ValidateKeyContext.cs
+++ b/src/CipherKey/Events/ValidateKeyContext.cs
@@ -20,7 +20,8 @@ namespace CipherKey.Events
             string apiKey)
             : base(context, scheme, options)
         {
-            ApiKey = apiKey;
+            ApiKey = ExtractAPIKey(apiKey);
+            Owner = ExtractAPIKeyOwner(apiKey);
         }
 
         /// <summary>
@@ -29,11 +30,16 @@ namespace CipherKey.Events
         public string ApiKey { get; }
 
         /// <summary>
+        /// Gets the API key owner validated.
+        /// </summary>
+        public string? Owner { get; }
+
+        /// <summary>
         /// Handles the successful validation of the API key.
         /// </summary>
         /// <param name="ownerName">The owner name to be added to claims as <see cref="ClaimTypes.Name"/> 
         /// and <see cref="ClaimTypes.NameIdentifier"/> if not already added with <paramref name="claims"/>.</param>
-        public void ValidationSucceeded(string ownerName)
+        public void ValidationSucceeded(string? ownerName)
         {
             Principal = CipherKeyUtils.BuildPrincipal(ownerName, Scheme.Name, Options.ClaimsIssuer ?? "", Options.Scope);
             Success();
@@ -52,6 +58,36 @@ namespace CipherKey.Events
             }
 
             Fail(failureMessage);
+        }
+
+        private string ExtractAPIKey(string apiKey)
+        {
+            if (apiKey.Contains("://"))
+            {
+                var apiKeyParts = apiKey.Split("://", StringSplitOptions.RemoveEmptyEntries);
+
+                if (apiKeyParts.Length == 2)
+                {
+                    return apiKeyParts[1];
+                }
+            }
+
+            return apiKey;
+        }
+
+        private string? ExtractAPIKeyOwner(string apiKey)
+        {
+            if (apiKey.Contains("://"))
+            {
+                var apiKeyParts = apiKey.Split("://", StringSplitOptions.RemoveEmptyEntries);
+
+                if (apiKeyParts.Length == 2)
+                {
+                    return apiKeyParts[0];
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/CipherKey/IApiKeyProvider.cs
+++ b/src/CipherKey/IApiKeyProvider.cs
@@ -10,8 +10,9 @@ namespace CipherKey
         /// Validates the provided key and returns an instance of <see cref="IApiKey"/>.
         /// </summary>
         /// <param name="key">The API key to validate.</param>
+        /// <param name="owner">The API key owner to validate.</param>
         /// <returns>An instance of <see cref="IApiKey"/> if validation is successful; 
         /// otherwise, returns null.</returns>
-        Task<IApiKey?> ProvideAsync(string key);
+        Task<IApiKey?> ProvideAsync(string key, string? owner = null);
     }
 }

--- a/tests/CipherKey.Tests.csproj
+++ b/tests/CipherKey.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Correctly handle `owner://` prefix in API key validation
- Updated `ProvideAsync` method to `Task<IApiKey?> ProvideAsync(string key, string? owner = null)` for better validation flexibility
- Enhanced documentation to reflect changes in API key validation process and method signature
- Updated project from .NET 7 to .NET 8

Closes #25