### PR TITLE
fix: handle missing Origin by falling back to IP in API key validation

### DIFF
--- a/samples/APIKeyAuthenticationSample/APIKeyAuthenticationSample.csproj
+++ b/samples/APIKeyAuthenticationSample/APIKeyAuthenticationSample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.1.0" />
+    <PackageReference Include="CipherKey" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/EventAuthenticationSample/EventAuthenticationSample.csproj
+++ b/samples/EventAuthenticationSample/EventAuthenticationSample.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.1.0" />
+    <PackageReference Include="CipherKey" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/samples/MultiAuthenticationSample/MultiAuthenticationSample.csproj
+++ b/samples/MultiAuthenticationSample/MultiAuthenticationSample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.1.0" />
+    <PackageReference Include="CipherKey" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/ProviderAuthenticationSample/ProviderAuthenticationSample.csproj
+++ b/samples/ProviderAuthenticationSample/ProviderAuthenticationSample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CipherKey" Version="1.1.0" />
+    <PackageReference Include="CipherKey" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/CipherKey/CipherKey.csproj
+++ b/src/CipherKey/CipherKey.csproj
@@ -6,9 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>CipherKey</AssemblyName>
     <AssemblyTitle>CipherKey</AssemblyTitle>
-    <AssemblyVersion>1.1.0</AssemblyVersion>
+    <AssemblyVersion>1.1.1</AssemblyVersion>
     <Product>CipherKey Library</Product>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>Diandson C. Ramos</Authors>
     <Owners>Diandson C. Ramos</Owners>
     <Copyright>Copyright (c) 2024 Diandson C. Ramos</Copyright>

--- a/src/CipherKey/CorsContext.cs
+++ b/src/CipherKey/CorsContext.cs
@@ -53,7 +53,7 @@ namespace CipherKey
 
             if (corsResult.IsOriginAllowed is false)
             {
-                Fail($"Origin {Request.Headers["Origin"]} not allowed.");
+                Fail($"Origin {Request.Headers.Origin} not allowed.");
             }
 
             if (!policy.AllowAnyMethod && !policy.Methods.Any(x => x == Request.Method))

--- a/tests/CipherKey.Tests.csproj
+++ b/tests/CipherKey.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Implemented fallback to IP address when `Origin` header is missing
- Ensured fallback handling does not compromise API security

Closes #27